### PR TITLE
fixed missing judge.

### DIFF
--- a/lbcapi/api.py
+++ b/lbcapi/api.py
@@ -107,7 +107,7 @@ class Connection():
                 # If HMAC Nonce is already used, then wait a little and try again
                 try:
                     response_json = response.json()
-                    if response_json.get('error', {}).get('error_code') == '42':
+                    if int(response_json.get('error', {}).get('error_code')) == 42:
                         time.sleep(0.1)
                         continue
                 except:


### PR DESCRIPTION
 '42' != 42; refer to response format:
{'error': {'message': 'Given nonce was too small.', 'error_code': 42}}