### PR TITLE
Support OS proxy

### DIFF
--- a/lbcapi/api.py
+++ b/lbcapi/api.py
@@ -114,6 +114,7 @@ class Connection():
 
                 # Send request
                 session = requests.Session()
+                session.proxies=urllib.request.getproxies()
                 response = session.send(api_request, stream=stream)
 
                 # If HMAC Nonce is already used, then wait a little and try again

--- a/lbcapi/api.py
+++ b/lbcapi/api.py
@@ -4,6 +4,7 @@ import hmac as hmac_lib
 import requests
 import sys
 import time
+from urllib import request
 try:
     # Python 3.x
     from urllib.parse import urlparse
@@ -114,7 +115,7 @@ class Connection():
 
                 # Send request
                 session = requests.Session()
-                session.proxies=urllib.request.getproxies()
+                session.proxies=request.getproxies()
                 response = session.send(api_request, stream=stream)
 
                 # If HMAC Nonce is already used, then wait a little and try again


### PR DESCRIPTION
Add the ability to use detected OS proxies (http_proxy and https_proxy) for the api requests to resolve an error:

requests.exceptions.ConnectionError: HTTPSConnectionPool(host='localbitcoins.com', port=443): Max retries exceeded with url: /api/myself/ (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x103e07810>: Failed to establish a new connection: [Errno 60] Operation timed out'))

Suggestions appreciated